### PR TITLE
add gcc to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN cd /assets/common && \
 
 FROM alpine:edge AS resource
 
-RUN apk update && apk --no-cache add bash curl git ca-certificates openssh
-
 COPY --from=build /assets/check /opt/resource/check
 COPY --from=build /assets/in /opt/resource/in
 COPY --from=build /assets/out /opt/resource/out

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:alpine AS build
 
+RUN apk update && apk --no-cache add bash curl git ca-certificates openssh gcc musl-dev
+
 COPY assets /assets
 
 RUN go build -o /assets/check /assets/check.go && \


### PR DESCRIPTION
gcc is required by go test, without this patch building the docker file results in an error because of missing gcc package required by go test 